### PR TITLE
(wip) Resolves #13, allow to configure a processor on the HTML converter

### DIFF
--- a/lib/asciidoctor/doctest/asciidoc_processor.rb
+++ b/lib/asciidoctor/doctest/asciidoc_processor.rb
@@ -11,7 +11,7 @@ module Asciidoctor
     ##
     # This class is basically a wrapper for +Asciidoctor.convert+ that allows to
     # preset and validate some common parameters.
-    class AsciidocConverter
+    class AsciidocProcessor
 
       # @return [Hash] the default options to be passed to Asciidoctor.
       attr_reader :default_opts

--- a/lib/asciidoctor/doctest/html/converter.rb
+++ b/lib/asciidoctor/doctest/html/converter.rb
@@ -8,11 +8,13 @@ using Corefines::Object::then
 
 module Asciidoctor::DocTest
   module HTML
-    class Converter < AsciidocConverter
+    class Converter
 
-      def initialize(paragraph_xpath: './p/node()', **opts)
+      attr_reader :processor
+
+      def initialize(paragraph_xpath: './p/node()', processor: AsciidocProcessor, **opts)
         @paragraph_xpath = paragraph_xpath
-        super opts
+        @processor = processor.new(opts) if processor.is_a? Class
       end
 
       def convert_examples(input_exmpl, output_exmpl)
@@ -24,7 +26,7 @@ module Asciidoctor::DocTest
         # When asserting inline examples, defaults to ignore paragraph "wrapper".
         opts[:include] ||= (@paragraph_xpath if input_exmpl.name.start_with? 'inline_')
 
-        actual = convert(input_exmpl.content, header_footer: opts[:header_footer])
+        actual = @processor.convert(input_exmpl.content, header_footer: opts[:header_footer])
           .then { |s| parse_html s }
           .then { |h| find_nodes h, opts[:include] }
           .then { |h| remove_nodes h, opts[:exclude] }

--- a/lib/asciidoctor/doctest/html/converter.rb
+++ b/lib/asciidoctor/doctest/html/converter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'asciidoctor/doctest/html_normalizer'
 require 'corefines'
 require 'htmlbeautifier'

--- a/lib/asciidoctor/doctest/io/asciidoc.rb
+++ b/lib/asciidoctor/doctest/io/asciidoc.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'asciidoctor/doctest/io/base'
 require 'corefines'
 
-using Corefines::Enumerable::map_send
 using Corefines::Object[:blank?, :presence]
 using Corefines::String::concat!
 
@@ -52,7 +51,7 @@ module Asciidoctor::DocTest
           Array.new.push(".#{exmpl.local_name}")
             .push(*exmpl.desc.lines.map(&:chomp))
             .push(*format_options(exmpl.opts))
-            .map_send(:prepend, '// ')
+            .map { |s| '// ' + s }
             .push(exmpl.content.presence)
             .compact
             .join("\n")

--- a/lib/asciidoctor/doctest/io/base.rb
+++ b/lib/asciidoctor/doctest/io/base.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'corefines'
 require 'pathname'
 

--- a/lib/asciidoctor/doctest/io/xml.rb
+++ b/lib/asciidoctor/doctest/io/xml.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'asciidoctor/doctest/io/base'
 require 'corefines'
 

--- a/lib/asciidoctor/doctest/rake_tasks.rb
+++ b/lib/asciidoctor/doctest/rake_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'asciidoctor/doctest/asciidoc_converter'
+require 'asciidoctor/doctest/asciidoc_processor'
 require 'asciidoctor/doctest/generator'
 require 'asciidoctor/doctest/test_reporter'
 require 'asciidoctor/doctest/tester'
@@ -56,7 +56,7 @@ module Asciidoctor
       attr_accessor :converter
 
       # @return [Hash] options for the Asciidoctor converter.
-      # @see AsciidocConverter#initialize
+      # @see AsciidocProcessor#initialize
       attr_accessor :converter_opts
 
       # @return [String] glob pattern to select examples to test or
@@ -102,6 +102,7 @@ module Asciidoctor
 
         fail ArgumentError, 'The output_examples must be provided!' unless @output_examples
 
+        # FIXME: How to configure the processor ?
         @converter = converter.new(converter_opts) if converter.is_a? Class
         @test_reporter ||= TestReporter.new($stdout, verbose: verbose?,
           title: "Running DocTest for the #{subject}.")

--- a/lib/asciidoctor/doctest/test_reporter.rb
+++ b/lib/asciidoctor/doctest/test_reporter.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # coding: utf-8
 require 'minitest'
 
@@ -52,7 +52,7 @@ module Asciidoctor
 
         return nil if filtered_results.empty?
 
-        str = "Aggregated results:\n"
+        str = +"Aggregated results:\n"
         filtered_results.each do |res|
           str << "\n#{res.symbol}  #{res.failure.result_label}: ".color(res.color)
           str << "#{res.name}\n#{res.failure.message.indent(3)}\n\n"
@@ -63,7 +63,7 @@ module Asciidoctor
 
       # @private
       def summary
-        str = "#{count} examples ("
+        str = +"#{count} examples ("
         str << [
           ("#{passes} passed".color(:green) if passes > 0),
           ("#{failures} failed".color(:red) if failures > 0),

--- a/spec/asciidoc_processor_spec.rb
+++ b/spec/asciidoc_processor_spec.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-describe DocTest::AsciidocConverter do
+describe DocTest::AsciidocProcessor do
 
   subject { described_class }
 

--- a/spec/html/converter_spec.rb
+++ b/spec/html/converter_spec.rb
@@ -37,7 +37,7 @@ module DocTest
       end
 
       before do
-        expect(converter).to receive(:convert)
+        expect(converter.processor).to receive(:convert)
           .with(input.content, converter_opts).and_return(rendered)
       end
 


### PR DESCRIPTION
The HTML converter can now be configured to use a "custom" processor.
By default we are using the `AsciidocProcessor` (previously known as `AsciidocConverter`).

Ultimately we should be able to configure the Rake task as follows...

```ruby
DocTest::RakeTasks.new do |t|
  t.output_examples :html, path: 'test/output/slim'
  t.input_examples :asciidoc, path: [ *DocTest.examples_path, 'examples' ]
  t.converter = DocTest::HTML::Converter
  t.processor = AsciidoctorJSCliProcessor
  t.converter_opts = { template_dirs: 'templates/slim' }
  t.converter_opts = { backend_name: 'revealjs' }
end
```

... but I did not figure out (yet) how to configure the converter in the `rake_tasks.rb` (see `FIXME`) ?
