### PR TITLE
Update dependencies to reflect Asciidoctor 2.0

### DIFF
--- a/asciidoctor-doctest.gemspec
+++ b/asciidoctor-doctest.gemspec
@@ -28,7 +28,7 @@ A tool for end-to-end testing of Asciidoctor backends based on comparing of text
   s.required_ruby_version = '>= 2.0'
 
   # runtime
-  s.add_runtime_dependency 'asciidoctor', '~> 1.5.0'
+  s.add_runtime_dependency 'asciidoctor', '>= 1.5.0', '< 2.1'
   s.add_runtime_dependency 'corefines', '~> 1.2'
   s.add_runtime_dependency 'diffy', '~> 3.0'
   s.add_runtime_dependency 'htmlbeautifier', '~> 1.0'


### PR DESCRIPTION
Right now asciidoctor-reveal.js builds fails with asciidoctor-doctest complains because of strict dependency requirements. See https://github.com/asciidoctor/asciidoctor-reveal.js/pull/216. I'm not sure this is the right way to fix it but we need to think about it.